### PR TITLE
HostIP's lat/long coordinates are ordered long,lat

### DIFF
--- a/lib/geo_location/geo_location.rb
+++ b/lib/geo_location/geo_location.rb
@@ -102,7 +102,7 @@ module GeoLocation
 
       element = hostip.at( "point coordinates" )
       if element
-        data[:latitude], data[:longitude] = element.text.split(',')
+        data[:longitude], data[:latitude] = element.text.split(',')
       end
       
       data[:ip] = ip


### PR DESCRIPTION
It's documented in the HostIP results and I completely missed it. Argh.
