### PR TITLE
Update API endpoint for MaxMind products and services

### DIFF
--- a/lib/geo_location/geo_location.rb
+++ b/lib/geo_location/geo_location.rb
@@ -22,7 +22,7 @@ module GeoLocation
     
     def maxmind(ip)
       if GeoLocation::dev.nil? || GeoLocation::dev.empty?
-        url = "http://geoip3.maxmind.com/b?l=#{GeoLocation::key}&i=#{ip}"
+        url = "https://geoip.maxmind.com/b?l=#{GeoLocation::key}&i=#{ip}"
         uri = URI.parse(url)
         data_from_maxmind_http_response(ip, Net::HTTP.get_response(uri).body)
       else


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)